### PR TITLE
Add user preferences for per-query optimization control

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Conduit uses contextual bandits (Thompson Sampling) to intelligently route queri
 
 - **ML-Driven Routing**: Learns from usage patterns vs static IF/ELSE rules
 - **Multi-Objective Optimization**: Balance cost, latency, and quality constraints
+- **User Preferences**: 4 optimization presets (balanced, quality, cost, speed) configurable per query
 - **Flexible Provider Support**:
   - Direct: 8 providers via PydanticAI - OpenAI, Anthropic, Google, Groq, Mistral, Cohere, AWS Bedrock, HuggingFace (structured outputs, type safety)
   - Extended: 100+ providers via LiteLLM integration (see `conduit_litellm/` and `docs/LITELLM_INTEGRATION.md`)
@@ -17,7 +18,7 @@ Conduit uses contextual bandits (Thompson Sampling) to intelligently route queri
 - **Redis Caching**: 10-40x performance improvement on repeated queries
 - **Graceful Degradation**: Core routing works without Redis
 - **9 Bandit Algorithms**: Contextual Thompson Sampling, LinUCB, Thompson Sampling, UCB1, Epsilon-Greedy, + 4 baselines
-- **Multi-Objective Rewards**: Composite rewards (70% quality + 20% cost + 10% latency)
+- **Multi-Objective Rewards**: Composite rewards (70% quality + 20% cost + 10% latency, customizable via preferences)
 - **Non-Stationarity Handling**: Sliding window adaptation for changing model quality/costs
 - **Dynamic Pricing**: 71+ models with auto-updated pricing from llm-prices.com (24h cache)
 - **Model Discovery**: Auto-detects available models based on your API keys (zero configuration)
@@ -42,6 +43,8 @@ asyncio.run(main())
 - **01_quickstart/**: hello_world.py (5 lines), simple_router.py
 - **02_routing/**: basic_routing.py, hybrid_routing.py, with_constraints.py
 - **03_optimization/**: caching.py, explicit_feedback.py
+- **04_litellm/**: LiteLLM integration examples (basic, multi-provider, custom config)
+- **05_personalization/**: User preferences for per-query optimization control
 
 ## Installation & Setup
 
@@ -84,6 +87,38 @@ Database setup:
 ```bash
 ./migrate.sh  # or: psql $DATABASE_URL < migrations/001_initial_schema.sql
 ```
+
+### User Preferences
+
+Control routing optimization per query with 4 presets:
+
+```python
+from conduit.core import Query, UserPreferences
+
+# Optimize for minimum cost
+query = Query(
+    text="Simple calculation",
+    preferences=UserPreferences(optimize_for="cost")
+)
+
+# Presets:
+# - balanced: Default (70% quality, 20% cost, 10% latency)
+# - quality:  Maximize quality (80% quality, 10% cost, 10% latency)
+# - cost:     Minimize cost (40% quality, 50% cost, 10% latency)
+# - speed:    Minimize latency (40% quality, 10% cost, 50% latency)
+```
+
+Customize presets in `conduit.yaml`:
+```yaml
+routing:
+  presets:
+    cost:
+      quality: 0.3  # Custom weights
+      cost: 0.6
+      latency: 0.1
+```
+
+See `examples/05_personalization/explicit_preferences.py` for full example.
 
 ## Tech Stack
 

--- a/conduit.yaml
+++ b/conduit.yaml
@@ -1,0 +1,31 @@
+# Conduit Configuration
+# See docs/configuration.md for detailed documentation
+
+routing:
+  # Default optimization strategy
+  # Options: balanced, quality, cost, speed
+  default_optimization: balanced
+
+  # Reward weight presets for routing decisions
+  # Each preset balances quality, cost, and latency differently
+  # Weights must sum to 1.0
+  presets:
+    balanced:
+      quality: 0.7    # Prioritize quality
+      cost: 0.2       # Moderate cost concern
+      latency: 0.1    # Low latency concern
+
+    quality:
+      quality: 0.8    # Maximize quality
+      cost: 0.1       # Minimal cost concern
+      latency: 0.1    # Minimal latency concern
+
+    cost:
+      quality: 0.4    # Acceptable quality
+      cost: 0.5       # Minimize cost
+      latency: 0.1    # Low latency concern
+
+    speed:
+      quality: 0.4    # Acceptable quality
+      cost: 0.1       # Low cost concern
+      latency: 0.5    # Minimize latency

--- a/conduit/core/__init__.py
+++ b/conduit/core/__init__.py
@@ -1,6 +1,6 @@
 """Core infrastructure for Conduit routing system."""
 
-from conduit.core.config import Settings, settings
+from conduit.core.config import Settings, load_preference_weights, settings
 from conduit.core.database import Database
 from conduit.core.exceptions import (
     AnalysisError,
@@ -22,6 +22,7 @@ from conduit.core.models import (
     Response,
     RoutingDecision,
     RoutingResult,
+    UserPreferences,
 )
 from conduit.core.pricing import ModelPricing
 
@@ -29,6 +30,7 @@ __all__ = [
     # Config
     "Settings",
     "settings",
+    "load_preference_weights",
     # Database
     "Database",
     # Exceptions
@@ -45,6 +47,7 @@ __all__ = [
     "Query",
     "QueryConstraints",
     "QueryFeatures",
+    "UserPreferences",
     "RoutingDecision",
     "Response",
     "Feedback",

--- a/conduit/core/models.py
+++ b/conduit/core/models.py
@@ -10,6 +10,30 @@ from typing import Any
 from uuid import uuid4
 
 from pydantic import BaseModel, Field, field_validator
+from typing import Literal
+
+
+class UserPreferences(BaseModel):
+    """User routing preferences for reward optimization.
+
+    Controls how Conduit balances quality, cost, and latency when
+    selecting models. Uses predefined presets for simplicity.
+
+    Presets:
+    - balanced: Default (0.7 quality, 0.2 cost, 0.1 latency)
+    - quality: Maximize quality (0.8 quality, 0.1 cost, 0.1 latency)
+    - cost: Minimize cost (0.4 quality, 0.5 cost, 0.1 latency)
+    - speed: Minimize latency (0.4 quality, 0.1 cost, 0.5 latency)
+
+    Example:
+        >>> preferences = UserPreferences(optimize_for="cost")
+        >>> query = Query(text="Simple math", preferences=preferences)
+    """
+
+    optimize_for: Literal["balanced", "quality", "cost", "speed"] = Field(
+        default="balanced",
+        description="Routing optimization priority"
+    )
 
 
 class QueryConstraints(BaseModel):
@@ -38,6 +62,10 @@ class Query(BaseModel):
     )
     constraints: QueryConstraints | None = Field(
         None, description="Routing constraints"
+    )
+    preferences: UserPreferences = Field(
+        default_factory=UserPreferences,
+        description="User routing preferences"
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc),

--- a/conduit/engines/router.py
+++ b/conduit/engines/router.py
@@ -4,7 +4,7 @@ import logging
 from typing import Any
 
 from conduit.cache import CacheConfig, CacheService
-from conduit.core.config import settings
+from conduit.core.config import load_preference_weights, settings
 from conduit.core.models import (
     Query,
     QueryConstraints,
@@ -116,6 +116,12 @@ class Router:
             >>> decision = await router.route(query)
             >>> print(f"Use {decision.selected_model} (confidence: {decision.confidence:.2f})")
         """
+        # Apply user preferences to reward weights
+        if query.preferences:
+            weights = load_preference_weights(query.preferences.optimize_for)
+            self.hybrid_router.ucb1.reward_weights = weights
+            self.hybrid_router.linucb.reward_weights = weights
+
         return await self.hybrid_router.route(query)
 
     def get_cache_stats(self) -> dict[str, Any] | None:

--- a/examples/05_personalization/explicit_preferences.py
+++ b/examples/05_personalization/explicit_preferences.py
@@ -1,0 +1,100 @@
+"""User Preferences Example.
+
+Demonstrates how to use explicit user preferences to control routing behavior.
+Conduit supports 4 optimization presets: balanced, quality, cost, and speed.
+"""
+
+import asyncio
+from conduit.core import Query, UserPreferences
+from conduit.engines import Router
+
+
+async def main() -> None:
+    """Demonstrate routing with different user preferences."""
+    print("🎯 User Preferences Example\n")
+    print("Conduit supports 4 optimization presets:")
+    print("  - balanced: Default (70% quality, 20% cost, 10% latency)")
+    print("  - quality:  Maximize quality (80% quality, 10% cost, 10% latency)")
+    print("  - cost:     Minimize cost (40% quality, 50% cost, 10% latency)")
+    print("  - speed:    Minimize latency (40% quality, 10% cost, 50% latency)\n")
+
+    # Initialize router (no special setup needed for preferences)
+    router = Router(
+        models=["gpt-4o-mini", "gpt-4o", "claude-3-5-sonnet-20241022"],
+        cache_enabled=False  # Disable caching for clearer routing demonstration
+    )
+
+    # Test queries demonstrating each preference
+    test_cases = [
+        ("balanced", "What is the capital of France?"),
+        ("quality", "Explain the theory of relativity in detail."),
+        ("cost", "What is 2+2?"),
+        ("speed", "Quick: What time is it in Tokyo?"),
+    ]
+
+    for optimize_for, query_text in test_cases:
+        print(f"\n{'='*70}")
+        print(f"Preference: {optimize_for}")
+        print(f"Query: {query_text}")
+        print(f"{'='*70}")
+
+        # Create query with specific preference
+        query = Query(
+            text=query_text,
+            preferences=UserPreferences(optimize_for=optimize_for)  # type: ignore[arg-type]
+        )
+
+        # Route query
+        decision = await router.route(query)
+
+        # Show results
+        print(f"✓ Selected Model: {decision.selected_model}")
+        print(f"  Confidence: {decision.confidence:.2f}")
+        print(f"  Reasoning: {decision.reasoning}")
+        print(f"  Reward Weights:")
+        print(f"    - Quality: {router.hybrid_router.ucb1.reward_weights['quality']:.1f}")
+        print(f"    - Cost: {router.hybrid_router.ucb1.reward_weights['cost']:.1f}")
+        print(f"    - Latency: {router.hybrid_router.ucb1.reward_weights['latency']:.1f}")
+
+    # Demonstrate default behavior (balanced)
+    print(f"\n{'='*70}")
+    print("Default Behavior (no preference specified → balanced)")
+    print(f"{'='*70}")
+
+    default_query = Query(text="Tell me about machine learning.")
+    default_decision = await router.route(default_query)
+
+    print(f"✓ Selected Model: {default_decision.selected_model}")
+    print(f"  Confidence: {default_decision.confidence:.2f}")
+    print(f"  Reward Weights (default to balanced):")
+    print(f"    - Quality: {router.hybrid_router.ucb1.reward_weights['quality']:.1f}")
+    print(f"    - Cost: {router.hybrid_router.ucb1.reward_weights['cost']:.1f}")
+    print(f"    - Latency: {router.hybrid_router.ucb1.reward_weights['latency']:.1f}")
+
+    # Custom configuration via conduit.yaml
+    print(f"\n{'='*70}")
+    print("Custom Configuration")
+    print(f"{'='*70}")
+    print("\nYou can customize preset weights in conduit.yaml:")
+    print("""
+routing:
+  presets:
+    cost:
+      quality: 0.3  # Even lower quality tolerance
+      cost: 0.6     # Even higher cost focus
+      latency: 0.1
+
+    custom_preset:
+      quality: 0.5
+      cost: 0.3
+      latency: 0.2
+""")
+    print("See conduit.yaml in the project root for the full configuration.")
+
+    # Cleanup
+    await router.close()
+    print("\n✨ Example complete!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "greenlet>=3.2.4",
     "psycopg2-binary>=2.9.11",
     "arbiter",
+    "pyyaml>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -134,4 +135,5 @@ dev = [
     "pytest-cov>=7.0.0",
     "pytest-mock>=3.15.1",
     "ruff>=0.14.6",
+    "types-pyyaml>=6.0.12.20250915",
 ]

--- a/tests/unit/test_user_preferences.py
+++ b/tests/unit/test_user_preferences.py
@@ -1,0 +1,190 @@
+"""Tests for user preferences and reward weight customization."""
+
+import pytest
+from pathlib import Path
+
+from conduit.core.config import load_preference_weights
+from conduit.core.models import Query, UserPreferences
+
+
+def test_user_preferences_defaults():
+    """Test UserPreferences model with default value."""
+    prefs = UserPreferences()
+    assert prefs.optimize_for == "balanced"
+
+
+def test_user_preferences_all_presets():
+    """Test all 4 preset options are valid."""
+    presets = ["balanced", "quality", "cost", "speed"]
+
+    for preset in presets:
+        prefs = UserPreferences(optimize_for=preset)  # type: ignore[arg-type]
+        assert prefs.optimize_for == preset
+
+
+def test_query_with_preferences():
+    """Test Query model includes preferences field."""
+    query = Query(text="Test query", preferences=UserPreferences(optimize_for="cost"))  # type: ignore[arg-type]
+
+    assert query.preferences.optimize_for == "cost"
+    assert query.text == "Test query"
+
+
+def test_query_default_preferences():
+    """Test Query uses default balanced preferences if not specified."""
+    query = Query(text="Test query")
+
+    assert query.preferences.optimize_for == "balanced"
+
+
+def test_load_preference_weights_balanced():
+    """Test loading balanced preset weights."""
+    weights = load_preference_weights("balanced")
+
+    assert weights["quality"] == 0.7
+    assert weights["cost"] == 0.2
+    assert weights["latency"] == 0.1
+    assert sum(weights.values()) == pytest.approx(1.0)
+
+
+def test_load_preference_weights_quality():
+    """Test loading quality preset weights."""
+    weights = load_preference_weights("quality")
+
+    assert weights["quality"] == 0.8
+    assert weights["cost"] == 0.1
+    assert weights["latency"] == 0.1
+    assert sum(weights.values()) == pytest.approx(1.0)
+
+
+def test_load_preference_weights_cost():
+    """Test loading cost preset weights."""
+    weights = load_preference_weights("cost")
+
+    assert weights["quality"] == 0.4
+    assert weights["cost"] == 0.5
+    assert weights["latency"] == 0.1
+    assert sum(weights.values()) == pytest.approx(1.0)
+
+
+def test_load_preference_weights_speed():
+    """Test loading speed preset weights."""
+    weights = load_preference_weights("speed")
+
+    assert weights["quality"] == 0.4
+    assert weights["cost"] == 0.1
+    assert weights["latency"] == 0.5
+    assert sum(weights.values()) == pytest.approx(1.0)
+
+
+def test_load_preference_weights_fallback_no_config(tmp_path, monkeypatch):
+    """Test fallback to defaults when conduit.yaml doesn't exist."""
+    # Change to temp directory without conduit.yaml
+    monkeypatch.chdir(tmp_path)
+
+    weights = load_preference_weights("balanced")
+
+    assert weights["quality"] == 0.7
+    assert weights["cost"] == 0.2
+    assert weights["latency"] == 0.1
+
+
+def test_load_preference_weights_fallback_invalid_yaml(tmp_path, monkeypatch):
+    """Test fallback to defaults when YAML is invalid."""
+    # Create invalid YAML file
+    config_path = tmp_path / "conduit.yaml"
+    config_path.write_text("invalid: yaml: content: [")
+
+    monkeypatch.chdir(tmp_path)
+
+    weights = load_preference_weights("balanced")
+
+    # Should still return defaults
+    assert weights["quality"] == 0.7
+    assert weights["cost"] == 0.2
+    assert weights["latency"] == 0.1
+
+
+def test_load_preference_weights_custom_yaml(tmp_path, monkeypatch):
+    """Test loading custom weights from conduit.yaml."""
+    # Create custom config
+    config_path = tmp_path / "conduit.yaml"
+    config_path.write_text("""
+routing:
+  default_optimization: balanced
+
+  presets:
+    balanced:
+      quality: 0.6
+      cost: 0.3
+      latency: 0.1
+    quality:
+      quality: 0.9
+      cost: 0.05
+      latency: 0.05
+""")
+
+    monkeypatch.chdir(tmp_path)
+
+    # Test balanced custom weights
+    weights_balanced = load_preference_weights("balanced")
+    assert weights_balanced["quality"] == 0.6
+    assert weights_balanced["cost"] == 0.3
+    assert weights_balanced["latency"] == 0.1
+
+    # Test quality custom weights
+    weights_quality = load_preference_weights("quality")
+    assert weights_quality["quality"] == 0.9
+    assert weights_quality["cost"] == 0.05
+    assert weights_quality["latency"] == 0.05
+
+
+@pytest.mark.asyncio
+async def test_router_uses_query_preferences():
+    """Test Router applies query preferences to reward weights."""
+    from conduit.engines.router import Router
+
+    # Create router
+    router = Router(models=["gpt-4o-mini", "gpt-4o"], cache_enabled=False)
+
+    # Create query with cost optimization
+    query = Query(
+        text="Simple query",
+        preferences=UserPreferences(optimize_for="cost")  # type: ignore[arg-type]
+    )
+
+    # Route query
+    decision = await router.route(query)
+
+    # Verify bandit has cost weights applied
+    assert router.hybrid_router.ucb1.reward_weights["cost"] == 0.5
+    assert router.hybrid_router.ucb1.reward_weights["quality"] == 0.4
+    assert router.hybrid_router.linucb.reward_weights["cost"] == 0.5
+    assert router.hybrid_router.linucb.reward_weights["quality"] == 0.4
+
+    # Cleanup
+    await router.close()
+
+
+@pytest.mark.asyncio
+async def test_router_default_preferences_when_none():
+    """Test Router uses default weights when query has default preferences."""
+    from conduit.engines.router import Router
+
+    # Create router
+    router = Router(models=["gpt-4o-mini", "gpt-4o"], cache_enabled=False)
+
+    # Create query with default preferences
+    query = Query(text="Simple query")  # Uses default balanced
+
+    # Route query
+    decision = await router.route(query)
+
+    # Verify bandit has balanced weights applied
+    assert router.hybrid_router.ucb1.reward_weights["quality"] == 0.7
+    assert router.hybrid_router.ucb1.reward_weights["cost"] == 0.2
+    assert router.hybrid_router.linucb.reward_weights["quality"] == 0.7
+    assert router.hybrid_router.linucb.reward_weights["cost"] == 0.2
+
+    # Cleanup
+    await router.close()

--- a/uv.lock
+++ b/uv.lock
@@ -617,6 +617,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-ai" },
     { name = "python-dotenv" },
+    { name = "pyyaml" },
     { name = "redis" },
     { name = "rich" },
     { name = "scikit-learn" },
@@ -649,6 +650,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-mock" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -678,6 +680,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.15.0" },
     { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
     { name = "redis", specifier = ">=5.0.0" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.14.0" },
@@ -698,6 +701,7 @@ dev = [
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "pytest-mock", specifier = ">=3.15.1" },
     { name = "ruff", specifier = ">=0.14.6" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 
 [[package]]
@@ -4397,6 +4401,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/93/29/47a346550fd2020dac9a7a6d033ea03fccb92fa47c726056618cc889745e/types-pyOpenSSL-24.1.0.20240722.tar.gz", hash = "sha256:47913b4678a01d879f503a12044468221ed8576263c1540dcb0484ca21b08c39", size = 8458, upload-time = "2024-07-22T02:32:22.558Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/98/05/c868a850b6fbb79c26f5f299b768ee0adc1f9816d3461dcf4287916f655b/types_pyOpenSSL-24.1.0.20240722-py3-none-any.whl", hash = "sha256:6a7a5d2ec042537934cfb4c9d4deb0e16c4c6250b09358df1f083682fe6fda54", size = 7499, upload-time = "2024-07-22T02:32:21.232Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20250915"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/69/3c51b36d04da19b92f9e815be12753125bd8bc247ba0470a982e6979e71c/types_pyyaml-6.0.12.20250915.tar.gz", hash = "sha256:0f8b54a528c303f0e6f7165687dd33fafa81c807fcac23f632b63aa624ced1d3", size = 17522, upload-time = "2025-09-15T03:01:00.728Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/e0/1eed384f02555dde685fff1a1ac805c1c7dcb6dd019c916fe659b1c1f9ec/types_pyyaml-6.0.12.20250915-py3-none-any.whl", hash = "sha256:e7d4d9e064e89a3b3cae120b4990cd370874d2bf12fa5f46c97018dd5d3c9ab6", size = 20338, upload-time = "2025-09-15T03:00:59.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements Issue #47: User preferences system with 4 optimization presets (balanced, quality, cost, speed) to control routing behavior per query.

Changes:
- Add UserPreferences model to conduit/core/models.py with 4 presets
- Create conduit.yaml configuration file with preset definitions
- Add load_preference_weights() function to load presets from YAML
- Update Router.route() to apply query preferences dynamically
- Add pyyaml and types-pyyaml dependencies
- Export UserPreferences and load_preference_weights in public API

Tests:
- Add tests/unit/test_user_preferences.py with 13 tests (all passing)
- Test all 4 presets, YAML loading, fallback behavior, Router integration

Examples:
- Add examples/05_personalization/explicit_preferences.py
- Demonstrates all 4 presets and custom configuration

Documentation:
- Add User Preferences section to README
- Update Key Features to mention preferences
- Update examples list with personalization category

Implementation follows "simplicity wins" philosophy:
- 4 simple presets instead of continuous spectrum
- YAML configuration for customization
- Good defaults (balanced) work out of box
- Zero configuration required to use defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)