### PR TITLE
Fix HuggingFace embedding provider API and model

### DIFF
--- a/conduit/engines/embeddings/factory.py
+++ b/conduit/engines/embeddings/factory.py
@@ -1,6 +1,7 @@
 """Factory for creating embedding providers."""
 
 import logging
+import os
 from typing import Any, Optional
 
 from conduit.engines.embeddings.base import EmbeddingProvider
@@ -55,10 +56,13 @@ def create_embedding_provider(
     provider_lower = provider.lower()
 
     if provider_lower == "huggingface":
-        model = model or "sentence-transformers/all-MiniLM-L6-v2"
+        # Check EMBEDDING_MODEL env var, then parameter, then default
+        model = model or os.getenv("EMBEDDING_MODEL") or "BAAI/bge-small-en-v1.5"
+        # Check for HF_TOKEN or HUGGINGFACE_API_KEY env vars as fallback
+        hf_api_key = api_key or os.getenv("HF_TOKEN") or os.getenv("HUGGINGFACE_API_KEY")
         return HuggingFaceEmbeddingProvider(
             model=model,
-            api_key=api_key,
+            api_key=hf_api_key,
             timeout=kwargs.get("timeout", 30.0),
         )
 

--- a/conduit/engines/embeddings/huggingface.py
+++ b/conduit/engines/embeddings/huggingface.py
@@ -13,27 +13,27 @@ logger = logging.getLogger(__name__)
 class HuggingFaceEmbeddingProvider(EmbeddingProvider):
     """HuggingFace Inference API embedding provider.
 
-    Free default option - no API key required for public models.
-    Uses HuggingFace Inference API which is free for public models.
+    Free default option - requires HF_TOKEN for the router API.
+    Uses HuggingFace Inference API router endpoint.
 
-    Default model: sentence-transformers/all-MiniLM-L6-v2 (384 dims)
+    Default model: BAAI/bge-small-en-v1.5 (384 dims)
     """
 
     def __init__(
         self,
-        model: str = "sentence-transformers/all-MiniLM-L6-v2",
+        model: str = "BAAI/bge-small-en-v1.5",
         api_key: Optional[str] = None,
         timeout: float = 30.0,
     ):
         """Initialize HuggingFace embedding provider.
 
         Args:
-            model: HuggingFace model identifier (default: all-MiniLM-L6-v2)
-            api_key: Optional API key for private models (not needed for public models)
+            model: HuggingFace model identifier (default: BAAI/bge-small-en-v1.5)
+            api_key: API key (HF_TOKEN) - required for router API
             timeout: Request timeout in seconds (default: 30s)
 
         Example:
-            >>> provider = HuggingFaceEmbeddingProvider()
+            >>> provider = HuggingFaceEmbeddingProvider(api_key="hf_...")
             >>> embedding = await provider.embed("Hello world")
             >>> len(embedding)
             384
@@ -41,10 +41,10 @@ class HuggingFaceEmbeddingProvider(EmbeddingProvider):
         self.model = model
         self.api_key = api_key
         self.timeout = timeout
-        self._dimension = 384  # all-MiniLM-L6-v2 dimension
+        self._dimension = 384  # bge-small-en-v1.5 dimension
 
-        # Build API URL (router.huggingface.co replaced deprecated api-inference.huggingface.co)
-        self.api_url = f"https://router.huggingface.co/hf-inference/pipeline/feature-extraction/{model}"
+        # Build API URL (router.huggingface.co/hf-inference/models/{model})
+        self.api_url = f"https://router.huggingface.co/hf-inference/models/{model}"
 
         # Build headers
         self.headers = {"Content-Type": "application/json"}


### PR DESCRIPTION
## Summary
- Update API URL to use `router.huggingface.co/hf-inference/models/{model}` (old api-inference.huggingface.co endpoint deprecated)
- Change default model to `BAAI/bge-small-en-v1.5` (384 dims) since sentence-transformers/all-MiniLM-L6-v2 no longer works on router API
- Add HF_TOKEN env var lookup in factory for authentication
- Add EMBEDDING_MODEL env var support for configurable models

Relates to #74

## Test plan
- [x] Verified embeddings work with new API endpoint
- [x] Tested BAAI/bge-small-en-v1.5 model returns 384-dim vectors
- [ ] Run embedding tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)