### PR TITLE
feat: Split Settings class into nested config classes (#80)

### DIFF
--- a/conduit/core/__init__.py
+++ b/conduit/core/__init__.py
@@ -1,7 +1,14 @@
 """Core infrastructure for Conduit routing system."""
 
 from conduit.core.config import (
+    APIConfig,
+    ArbiterConfig,
+    DatabaseConfig,
+    MLConfig,
+    ProviderConfig,
+    RedisConfig,
     Settings,
+    TelemetryConfig,
     load_preference_weights,
     settings,
 )
@@ -44,6 +51,14 @@ __all__ = [
     "Settings",
     "settings",
     "load_preference_weights",
+    # Nested Config Classes
+    "DatabaseConfig",
+    "RedisConfig",
+    "ProviderConfig",
+    "MLConfig",
+    "APIConfig",
+    "ArbiterConfig",
+    "TelemetryConfig",
     # Context Detection
     "ContextDetector",
     # Database

--- a/conduit/core/config.py
+++ b/conduit/core/config.py
@@ -2,30 +2,276 @@
 
 This module provides centralized configuration loading from environment
 variables with validation and type safety.
+
+Configuration is organized into nested classes for better separation of concerns:
+- DatabaseConfig: PostgreSQL connection settings
+- RedisConfig: Redis cache and circuit breaker settings
+- ProviderConfig: LLM provider API keys
+- MLConfig: Embedding and bandit algorithm settings
+- APIConfig: REST API settings
+- ArbiterConfig: LLM-as-judge evaluation settings
+- TelemetryConfig: OpenTelemetry settings
 """
 
 import yaml
 from pathlib import Path
 from typing import Literal
 
-from pydantic import Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
-class Settings(BaseSettings):
-    """Application configuration from environment variables."""
+# =============================================================================
+# Nested Configuration Classes
+# =============================================================================
 
-    model_config = SettingsConfigDict(
-        env_file=".env", env_file_encoding="utf-8", case_sensitive=False, extra="ignore"
+
+class DatabaseConfig(BaseModel):
+    """PostgreSQL database configuration."""
+
+    url: str = Field(default="", description="PostgreSQL connection string")
+    pool_size: int = Field(default=20, description="Connection pool size", ge=1, le=100)
+
+
+class RedisConfig(BaseModel):
+    """Redis cache and circuit breaker configuration."""
+
+    url: str = Field(default="redis://localhost:6379", description="Redis URL")
+    cache_enabled: bool = Field(default=True, description="Enable query feature caching")
+    cache_ttl: int = Field(
+        default=86400, description="Cache TTL in seconds (24 hours)", ge=60, le=86400
+    )
+    max_retries: int = Field(default=3, description="Redis operation max retries", ge=0, le=10)
+    timeout: int = Field(default=5, description="Redis operation timeout seconds", ge=1, le=30)
+    circuit_breaker_threshold: int = Field(
+        default=5, description="Failures before opening circuit", ge=1, le=20
+    )
+    circuit_breaker_timeout: int = Field(
+        default=300, description="Circuit breaker timeout seconds (5 min)", ge=60, le=3600
     )
 
-    # Supabase Database
+
+class ProviderConfig(BaseModel):
+    """LLM provider API keys and credentials."""
+
+    openai_api_key: str = Field(default="", description="OpenAI API key")
+    anthropic_api_key: str = Field(default="", description="Anthropic API key")
+    google_api_key: str = Field(default="", description="Google/Gemini API key")
+    groq_api_key: str = Field(default="", description="Groq API key")
+    mistral_api_key: str = Field(default="", description="Mistral API key")
+    cohere_api_key: str = Field(default="", description="Cohere API key")
+    huggingface_api_key: str = Field(default="", description="HuggingFace API key")
+    aws_access_key_id: str = Field(default="", description="AWS Access Key (for Bedrock)")
+    aws_secret_access_key: str = Field(default="", description="AWS Secret Key (for Bedrock)")
+    aws_region: str = Field(default="us-east-1", description="AWS Region (for Bedrock)")
+
+
+class MLConfig(BaseModel):
+    """Machine learning and bandit algorithm configuration."""
+
+    # Embedding settings
+    embedding_provider: str = Field(
+        default="huggingface",
+        description="Embedding provider type (huggingface, openai, cohere, sentence-transformers)",
+    )
+    embedding_model: str = Field(
+        default="",
+        description="Embedding model identifier (provider-specific, empty = use provider default)",
+    )
+    embedding_api_key: str = Field(
+        default="",
+        description="API key for embedding provider (if required, defaults to provider-specific env var)",
+    )
+
+    # Default models for routing
+    default_models: list[str] = Field(
+        default=[
+            "gpt-4o-mini",
+            "gpt-4o",
+            "claude-3-5-sonnet-20241022",
+            "claude-3-opus-20240229",
+        ],
+        description="Available models for routing (must match pricing database IDs)",
+    )
+
+    # PCA dimensionality reduction
+    use_pca: bool = Field(
+        default=False, description="Enable PCA dimensionality reduction for embeddings"
+    )
+    pca_dimensions: int = Field(
+        default=64, description="Target embedding dimensions after PCA", ge=8, le=384
+    )
+    pca_model_path: str = Field(default="models/pca.pkl", description="Path to fitted PCA model")
+
+    # Bandit algorithm parameters
+    exploration_rate: float = Field(
+        default=0.1, description="Exploration rate (epsilon)", ge=0.0, le=1.0
+    )
+    reward_weight_quality: float = Field(
+        default=0.5, description="Quality weight in reward", ge=0.0, le=1.0
+    )
+    reward_weight_cost: float = Field(
+        default=0.3, description="Cost weight in reward", ge=0.0, le=1.0
+    )
+    reward_weight_latency: float = Field(
+        default=0.2, description="Latency weight in reward", ge=0.0, le=1.0
+    )
+    bandit_window_size: int = Field(
+        default=1000,
+        description="Sliding window size for non-stationarity (0 = unlimited history)",
+        ge=0,
+        le=100000,
+    )
+    bandit_success_threshold: float = Field(
+        default=0.85,
+        description="Reward threshold for counting a query as 'successful' (statistics only)",
+        ge=0.0,
+        le=1.0,
+    )
+
+    # Hybrid routing configuration
+    use_hybrid_routing: bool = Field(
+        default=False,
+        description="Enable hybrid routing (UCB1→LinUCB warm start for 30% faster convergence)",
+    )
+    hybrid_switch_threshold: int = Field(
+        default=2000,
+        description="Query count to switch from UCB1 to LinUCB in hybrid mode",
+        ge=100,
+        le=10000,
+    )
+    hybrid_ucb1_c: float = Field(
+        default=1.5,
+        description="UCB1 exploration parameter (c) for hybrid routing phase 1",
+        ge=0.1,
+        le=10.0,
+    )
+    hybrid_linucb_alpha: float = Field(
+        default=1.0,
+        description="LinUCB exploration parameter (alpha) for hybrid routing phase 2",
+        ge=0.1,
+        le=10.0,
+    )
+
+    # Execution timeouts
+    llm_timeout_default: float = Field(
+        default=60.0, description="Default LLM call timeout in seconds", ge=1.0, le=300.0
+    )
+    llm_timeout_fast: float = Field(
+        default=30.0, description="Timeout for fast models (mini) in seconds", ge=1.0, le=300.0
+    )
+    llm_timeout_premium: float = Field(
+        default=90.0, description="Timeout for premium models (opus) in seconds", ge=1.0, le=300.0
+    )
+
+    @model_validator(mode="after")
+    def validate_reward_weights_sum(self) -> "MLConfig":
+        """Validate reward weights sum to approximately 1.0."""
+        total = self.reward_weight_quality + self.reward_weight_cost + self.reward_weight_latency
+        if abs(total - 1.0) > 0.01:
+            raise ValueError(
+                f"Reward weights must sum to 1.0, got {total:.3f} "
+                f"(quality={self.reward_weight_quality}, "
+                f"cost={self.reward_weight_cost}, "
+                f"latency={self.reward_weight_latency})"
+            )
+        return self
+
+    @property
+    def reward_weights(self) -> dict[str, float]:
+        """Return reward weights as dictionary."""
+        return {
+            "quality": self.reward_weight_quality,
+            "cost": self.reward_weight_cost,
+            "latency": self.reward_weight_latency,
+        }
+
+
+class APIConfig(BaseModel):
+    """REST API configuration."""
+
+    host: str = Field(default="0.0.0.0", description="API host")
+    port: int = Field(default=8000, description="API port", ge=1, le=65535)
+    rate_limit: int = Field(default=100, description="Requests per minute per user", ge=1, le=1000)
+    key: str = Field(default="", description="API key for authentication (empty = disabled)")
+    require_auth: bool = Field(
+        default=False, description="Require API key authentication for /v1/* endpoints"
+    )
+    max_request_size: int = Field(
+        default=10_000, description="Maximum request body size in bytes", ge=1000, le=1_000_000
+    )
+
+
+class ArbiterConfig(BaseModel):
+    """Arbiter LLM-as-judge evaluation configuration."""
+
+    enabled: bool = Field(default=False, description="Enable Arbiter LLM-as-judge evaluation")
+    sample_rate: float = Field(
+        default=0.1, description="Fraction of responses to evaluate (0.0-1.0)", ge=0.0, le=1.0
+    )
+    daily_budget: float = Field(
+        default=10.0, description="Maximum daily evaluation budget (USD)", ge=0.0, le=1000.0
+    )
+    model: str = Field(default="gpt-4o-mini", description="Model for evaluation (cheap recommended)")
+
+
+class TelemetryConfig(BaseModel):
+    """OpenTelemetry instrumentation configuration."""
+
+    enabled: bool = Field(default=False, description="Enable OpenTelemetry instrumentation")
+    service_name: str = Field(default="conduit-router", description="Service name for telemetry")
+    exporter_otlp_endpoint: str = Field(
+        default="http://localhost:4318", description="OTLP gRPC endpoint"
+    )
+    exporter_otlp_headers: str = Field(default="", description="OTLP headers (e.g., 'api-key=xxx')")
+    traces_enabled: bool = Field(default=True, description="Enable trace collection")
+    metrics_enabled: bool = Field(default=True, description="Enable metrics collection")
+
+
+# =============================================================================
+# Main Settings Class
+# =============================================================================
+
+
+class Settings(BaseSettings):
+    """Application configuration from environment variables.
+
+    Configuration is organized into nested classes for better maintainability:
+    - database: PostgreSQL settings
+    - redis: Redis cache settings
+    - providers: LLM API keys
+    - ml: Machine learning and bandit settings
+    - api: REST API settings
+    - arbiter: LLM-as-judge evaluation
+    - telemetry: OpenTelemetry settings
+
+    For backwards compatibility, flat attribute access is still supported
+    via property aliases (e.g., settings.database_url -> settings.database.url).
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        case_sensitive=False,
+        extra="ignore",
+        env_nested_delimiter="__",
+    )
+
+    # ==========================================================================
+    # Nested Configuration (New Structure)
+    # ==========================================================================
+
+    # Note: Pydantic-settings doesn't support nested BaseModel directly,
+    # so we use flat fields with env vars and construct nested objects
+    # via properties for organizational access.
+
+    # Database Configuration (flat for env var support)
     database_url: str = Field(default="", description="PostgreSQL connection string")
     database_pool_size: int = Field(
         default=20, description="Connection pool size", ge=1, le=100
     )
 
-    # Redis Cache
+    # Redis Configuration (flat for env var support)
     redis_url: str = Field(default="redis://localhost:6379", description="Redis URL")
     redis_cache_enabled: bool = Field(
         default=True, description="Enable query feature caching"
@@ -46,7 +292,7 @@ class Settings(BaseSettings):
         default=300, description="Circuit breaker timeout seconds (5 min)", ge=60, le=3600
     )
 
-    # LLM Provider API Keys (all providers supported by PydanticAI)
+    # LLM Provider API Keys
     openai_api_key: str = Field(default="", description="OpenAI API key")
     anthropic_api_key: str = Field(default="", description="Anthropic API key")
     google_api_key: str = Field(default="", description="Google/Gemini API key")
@@ -73,10 +319,10 @@ class Settings(BaseSettings):
     )
     default_models: list[str] = Field(
         default=[
-            "gpt-4o-mini",                  # OpenAI - cheap, fast, good quality
-            "gpt-4o",                       # OpenAI - flagship, balanced
-            "claude-3-5-sonnet-20241022",   # Anthropic - current popular
-            "claude-3-opus-20240229",       # Anthropic - premium quality
+            "gpt-4o-mini",
+            "gpt-4o",
+            "claude-3-5-sonnet-20241022",
+            "claude-3-opus-20240229",
         ],
         description="Available models for routing (must match pricing database IDs)",
     )
@@ -216,6 +462,10 @@ class Settings(BaseSettings):
         default=True, description="Enable metrics collection"
     )
 
+    # ==========================================================================
+    # Validators
+    # ==========================================================================
+
     @model_validator(mode="after")
     def validate_reward_weights_sum(self) -> "Settings":
         """Validate reward weights sum to approximately 1.0."""
@@ -224,7 +474,7 @@ class Settings(BaseSettings):
             + self.reward_weight_cost
             + self.reward_weight_latency
         )
-        if abs(total - 1.0) > 0.01:  # Allow small floating point variance
+        if abs(total - 1.0) > 0.01:
             raise ValueError(
                 f"Reward weights must sum to 1.0, got {total:.3f} "
                 f"(quality={self.reward_weight_quality}, "
@@ -232,6 +482,111 @@ class Settings(BaseSettings):
                 f"latency={self.reward_weight_latency})"
             )
         return self
+
+    # ==========================================================================
+    # Nested Config Properties (Organizational Access)
+    # ==========================================================================
+
+    @property
+    def database(self) -> DatabaseConfig:
+        """Get database configuration as nested object."""
+        return DatabaseConfig(
+            url=self.database_url,
+            pool_size=self.database_pool_size,
+        )
+
+    @property
+    def redis(self) -> RedisConfig:
+        """Get Redis configuration as nested object."""
+        return RedisConfig(
+            url=self.redis_url,
+            cache_enabled=self.redis_cache_enabled,
+            cache_ttl=self.redis_cache_ttl,
+            max_retries=self.redis_max_retries,
+            timeout=self.redis_timeout,
+            circuit_breaker_threshold=self.redis_circuit_breaker_threshold,
+            circuit_breaker_timeout=self.redis_circuit_breaker_timeout,
+        )
+
+    @property
+    def providers(self) -> ProviderConfig:
+        """Get provider API keys as nested object."""
+        return ProviderConfig(
+            openai_api_key=self.openai_api_key,
+            anthropic_api_key=self.anthropic_api_key,
+            google_api_key=self.google_api_key,
+            groq_api_key=self.groq_api_key,
+            mistral_api_key=self.mistral_api_key,
+            cohere_api_key=self.cohere_api_key,
+            huggingface_api_key=self.huggingface_api_key,
+            aws_access_key_id=self.aws_access_key_id,
+            aws_secret_access_key=self.aws_secret_access_key,
+            aws_region=self.aws_region,
+        )
+
+    @property
+    def ml(self) -> MLConfig:
+        """Get ML configuration as nested object."""
+        return MLConfig(
+            embedding_provider=self.embedding_provider,
+            embedding_model=self.embedding_model,
+            embedding_api_key=self.embedding_api_key,
+            default_models=self.default_models,
+            use_pca=self.use_pca,
+            pca_dimensions=self.pca_dimensions,
+            pca_model_path=self.pca_model_path,
+            exploration_rate=self.exploration_rate,
+            reward_weight_quality=self.reward_weight_quality,
+            reward_weight_cost=self.reward_weight_cost,
+            reward_weight_latency=self.reward_weight_latency,
+            bandit_window_size=self.bandit_window_size,
+            bandit_success_threshold=self.bandit_success_threshold,
+            use_hybrid_routing=self.use_hybrid_routing,
+            hybrid_switch_threshold=self.hybrid_switch_threshold,
+            hybrid_ucb1_c=self.hybrid_ucb1_c,
+            hybrid_linucb_alpha=self.hybrid_linucb_alpha,
+            llm_timeout_default=self.llm_timeout_default,
+            llm_timeout_fast=self.llm_timeout_fast,
+            llm_timeout_premium=self.llm_timeout_premium,
+        )
+
+    @property
+    def api(self) -> APIConfig:
+        """Get API configuration as nested object."""
+        return APIConfig(
+            host=self.api_host,
+            port=self.api_port,
+            rate_limit=self.api_rate_limit,
+            key=self.api_key,
+            require_auth=self.api_require_auth,
+            max_request_size=self.api_max_request_size,
+        )
+
+    @property
+    def arbiter(self) -> ArbiterConfig:
+        """Get Arbiter configuration as nested object."""
+        return ArbiterConfig(
+            enabled=self.arbiter_enabled,
+            sample_rate=self.arbiter_sample_rate,
+            daily_budget=self.arbiter_daily_budget,
+            model=self.arbiter_model,
+        )
+
+    @property
+    def telemetry(self) -> TelemetryConfig:
+        """Get telemetry configuration as nested object."""
+        return TelemetryConfig(
+            enabled=self.otel_enabled,
+            service_name=self.otel_service_name,
+            exporter_otlp_endpoint=self.otel_exporter_otlp_endpoint,
+            exporter_otlp_headers=self.otel_exporter_otlp_headers,
+            traces_enabled=self.otel_traces_enabled,
+            metrics_enabled=self.otel_metrics_enabled,
+        )
+
+    # ==========================================================================
+    # Utility Properties
+    # ==========================================================================
 
     @property
     def reward_weights(self) -> dict[str, float]:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -3,7 +3,16 @@
 import pytest
 from pydantic import ValidationError
 
-from conduit.core.config import Settings
+from conduit.core.config import (
+    APIConfig,
+    ArbiterConfig,
+    DatabaseConfig,
+    MLConfig,
+    ProviderConfig,
+    RedisConfig,
+    Settings,
+    TelemetryConfig,
+)
 
 
 class TestSettings:
@@ -110,3 +119,225 @@ class TestSettings:
                 database_url="postgresql://localhost/test",
                 api_port=0  # Too low
             )
+
+
+class TestNestedConfigClasses:
+    """Tests for nested configuration classes."""
+
+    def test_database_config_defaults(self):
+        """Test DatabaseConfig default values."""
+        config = DatabaseConfig()
+        assert config.url == ""
+        assert config.pool_size == 20
+
+    def test_database_config_validation(self):
+        """Test DatabaseConfig validation."""
+        config = DatabaseConfig(url="postgresql://localhost/test", pool_size=50)
+        assert config.url == "postgresql://localhost/test"
+        assert config.pool_size == 50
+
+        with pytest.raises(ValidationError):
+            DatabaseConfig(pool_size=0)  # Below minimum
+
+        with pytest.raises(ValidationError):
+            DatabaseConfig(pool_size=200)  # Above maximum
+
+    def test_redis_config_defaults(self):
+        """Test RedisConfig default values."""
+        config = RedisConfig()
+        assert config.url == "redis://localhost:6379"
+        assert config.cache_enabled is True
+        assert config.cache_ttl == 86400
+        assert config.max_retries == 3
+        assert config.timeout == 5
+        assert config.circuit_breaker_threshold == 5
+        assert config.circuit_breaker_timeout == 300
+
+    def test_redis_config_validation(self):
+        """Test RedisConfig validation."""
+        config = RedisConfig(cache_ttl=3600, max_retries=5)
+        assert config.cache_ttl == 3600
+        assert config.max_retries == 5
+
+        with pytest.raises(ValidationError):
+            RedisConfig(cache_ttl=30)  # Below minimum (60)
+
+    def test_provider_config_defaults(self):
+        """Test ProviderConfig default values."""
+        config = ProviderConfig()
+        assert config.openai_api_key == ""
+        assert config.anthropic_api_key == ""
+        assert config.google_api_key == ""
+        assert config.aws_region == "us-east-1"
+
+    def test_ml_config_defaults(self):
+        """Test MLConfig default values."""
+        config = MLConfig()
+        assert config.embedding_provider == "huggingface"
+        assert config.embedding_model == ""
+        assert config.use_pca is False
+        assert config.pca_dimensions == 64
+        assert config.exploration_rate == 0.1
+        assert config.reward_weight_quality == 0.5
+        assert config.reward_weight_cost == 0.3
+        assert config.reward_weight_latency == 0.2
+
+    def test_ml_config_reward_weights_validation(self):
+        """Test MLConfig reward weights must sum to 1.0."""
+        with pytest.raises(ValidationError, match="Reward weights must sum to 1.0"):
+            MLConfig(
+                reward_weight_quality=0.5,
+                reward_weight_cost=0.5,
+                reward_weight_latency=0.5,  # Sum = 1.5
+            )
+
+    def test_ml_config_reward_weights_property(self):
+        """Test MLConfig reward_weights property."""
+        config = MLConfig()
+        weights = config.reward_weights
+        assert weights == {"quality": 0.5, "cost": 0.3, "latency": 0.2}
+
+    def test_api_config_defaults(self):
+        """Test APIConfig default values."""
+        config = APIConfig()
+        assert config.host == "0.0.0.0"
+        assert config.port == 8000
+        assert config.rate_limit == 100
+        assert config.key == ""
+        assert config.require_auth is False
+        assert config.max_request_size == 10_000
+
+    def test_api_config_validation(self):
+        """Test APIConfig validation."""
+        with pytest.raises(ValidationError):
+            APIConfig(port=70000)  # Out of range
+
+    def test_arbiter_config_defaults(self):
+        """Test ArbiterConfig default values."""
+        config = ArbiterConfig()
+        assert config.enabled is False
+        assert config.sample_rate == 0.1
+        assert config.daily_budget == 10.0
+        assert config.model == "gpt-4o-mini"
+
+    def test_arbiter_config_validation(self):
+        """Test ArbiterConfig validation."""
+        with pytest.raises(ValidationError):
+            ArbiterConfig(sample_rate=1.5)  # Above maximum (1.0)
+
+    def test_telemetry_config_defaults(self):
+        """Test TelemetryConfig default values."""
+        config = TelemetryConfig()
+        assert config.enabled is False
+        assert config.service_name == "conduit-router"
+        assert config.exporter_otlp_endpoint == "http://localhost:4318"
+        assert config.traces_enabled is True
+        assert config.metrics_enabled is True
+
+
+class TestNestedConfigProperties:
+    """Tests for Settings nested config property accessors."""
+
+    def test_database_property(self):
+        """Test Settings.database property returns DatabaseConfig."""
+        settings = Settings(
+            database_url="postgresql://localhost/test",
+            database_pool_size=30,
+        )
+        db = settings.database
+        assert isinstance(db, DatabaseConfig)
+        assert db.url == "postgresql://localhost/test"
+        assert db.pool_size == 30
+
+    def test_redis_property(self):
+        """Test Settings.redis property returns RedisConfig."""
+        settings = Settings(
+            database_url="postgresql://localhost/test",
+            redis_url="redis://custom:6379",
+            redis_cache_enabled=False,
+            redis_cache_ttl=7200,
+        )
+        redis = settings.redis
+        assert isinstance(redis, RedisConfig)
+        assert redis.url == "redis://custom:6379"
+        assert redis.cache_enabled is False
+        assert redis.cache_ttl == 7200
+
+    def test_providers_property(self):
+        """Test Settings.providers property returns ProviderConfig."""
+        settings = Settings(
+            database_url="postgresql://localhost/test",
+            openai_api_key="sk-test123",
+            anthropic_api_key="sk-ant-test",
+        )
+        providers = settings.providers
+        assert isinstance(providers, ProviderConfig)
+        assert providers.openai_api_key == "sk-test123"
+        assert providers.anthropic_api_key == "sk-ant-test"
+
+    def test_ml_property(self):
+        """Test Settings.ml property returns MLConfig."""
+        settings = Settings(
+            database_url="postgresql://localhost/test",
+            embedding_provider="openai",
+            use_pca=True,
+            pca_dimensions=128,
+        )
+        ml = settings.ml
+        assert isinstance(ml, MLConfig)
+        assert ml.embedding_provider == "openai"
+        assert ml.use_pca is True
+        assert ml.pca_dimensions == 128
+
+    def test_api_property(self):
+        """Test Settings.api property returns APIConfig."""
+        settings = Settings(
+            database_url="postgresql://localhost/test",
+            api_host="127.0.0.1",
+            api_port=9000,
+            api_require_auth=True,
+        )
+        api = settings.api
+        assert isinstance(api, APIConfig)
+        assert api.host == "127.0.0.1"
+        assert api.port == 9000
+        assert api.require_auth is True
+
+    def test_arbiter_property(self):
+        """Test Settings.arbiter property returns ArbiterConfig."""
+        settings = Settings(
+            database_url="postgresql://localhost/test",
+            arbiter_enabled=True,
+            arbiter_sample_rate=0.25,
+            arbiter_daily_budget=50.0,
+        )
+        arbiter = settings.arbiter
+        assert isinstance(arbiter, ArbiterConfig)
+        assert arbiter.enabled is True
+        assert arbiter.sample_rate == 0.25
+        assert arbiter.daily_budget == 50.0
+
+    def test_telemetry_property(self):
+        """Test Settings.telemetry property returns TelemetryConfig."""
+        settings = Settings(
+            database_url="postgresql://localhost/test",
+            otel_enabled=True,
+            otel_service_name="my-service",
+        )
+        telemetry = settings.telemetry
+        assert isinstance(telemetry, TelemetryConfig)
+        assert telemetry.enabled is True
+        assert telemetry.service_name == "my-service"
+
+    def test_backwards_compatibility(self):
+        """Test flat attribute access still works (backwards compatibility)."""
+        settings = Settings(
+            database_url="postgresql://localhost/test",
+            redis_cache_ttl=7200,
+            api_port=9000,
+        )
+        # Both flat and nested access should work
+        assert settings.redis_cache_ttl == 7200
+        assert settings.redis.cache_ttl == 7200
+        assert settings.api_port == 9000
+        assert settings.api.port == 9000


### PR DESCRIPTION
## Summary
- Organize Settings class into 7 domain-specific nested config classes (DatabaseConfig, RedisConfig, ProviderConfig, MLConfig, APIConfig, ArbiterConfig, TelemetryConfig)
- Maintain full backwards compatibility with flat attribute access for environment variables
- Add property accessors for organized nested access (e.g., `settings.database.url`)
- Add 21 new tests for nested config classes (29 total, all passing)

## Test plan
- [x] All 29 config tests pass
- [x] Nested access works: `settings.database.url`, `settings.redis.cache_ttl`
- [x] Flat access still works: `settings.database_url`, `settings.redis_cache_ttl`
- [x] Environment variable loading unchanged
- [x] Config coverage improved from 83% to 89%

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)