### PR TITLE
Add CI badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # Conduit Router
 
+[![CI](https://github.com/ashita-ai/conduit/actions/workflows/ci.yml/badge.svg)](https://github.com/ashita-ai/conduit/actions/workflows/ci.yml)
+[![Coverage](https://img.shields.io/badge/coverage-81%25-brightgreen)](https://github.com/ashita-ai/conduit/actions/workflows/ci.yml)
+[![Python 3.11+](https://img.shields.io/badge/python-3.11+-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 **Cut your LLM costs 30-50% without sacrificing quality.**
 
 ML-powered routing system that learns which model to use for each type of query. Unlike static rule-based routers, Conduit continuously improves its decisions through feedback loops.


### PR DESCRIPTION
## Summary
Adds CI status badges to README header for transparency and credibility.

## Changes
- Added CI workflow status badge
- Added test coverage badge (81%)
- Added Python version requirement badge (3.11+)
- Added MIT License badge

## CI Enforcement
CI workflow already enforces:
- Coverage >= 80% (--cov-fail-under=80)
- All tests passing
- Ruff linting clean
- Black formatting check

Closes #97