### PR TITLE
fix: Add model_id validation to all bandit algorithms

### DIFF
--- a/conduit/engines/bandits/contextual_thompson_sampling.py
+++ b/conduit/engines/bandits/contextual_thompson_sampling.py
@@ -230,6 +230,13 @@ class ContextualThompsonSamplingBandit(BanditAlgorithm):
         """
         model_id = feedback.model_id
 
+        # Validate model_id exists in available arms
+        if model_id not in self.arms:
+            raise ValueError(
+                f"Model ID '{model_id}' not in arms. "
+                f"Available: {list(self.arms.keys())}"
+            )
+
         # Calculate composite reward from quality, cost, and latency (Phase 3)
         reward = feedback.calculate_reward(
             quality_weight=self.reward_weights["quality"],

--- a/conduit/engines/bandits/dueling.py
+++ b/conduit/engines/bandits/dueling.py
@@ -196,6 +196,21 @@ class DuelingBandit(BanditAlgorithm):
             ... )
             >>> await bandit.update(feedback, features)
         """
+        model_a_id = feedback.model_a_id
+        model_b_id = feedback.model_b_id
+
+        # Validate both model_ids exist in available arms
+        if model_a_id not in self.arms:
+            raise ValueError(
+                f"Model ID '{model_a_id}' not in arms. "
+                f"Available: {list(self.arms.keys())}"
+            )
+        if model_b_id not in self.arms:
+            raise ValueError(
+                f"Model ID '{model_b_id}' not in arms. "
+                f"Available: {list(self.arms.keys())}"
+            )
+
         # Extract feature vector (d × 1)
         x = self._extract_features(features)
 
@@ -204,8 +219,6 @@ class DuelingBandit(BanditAlgorithm):
 
         # Update weights for both arms
         # Winner gets positive gradient, loser gets negative
-        model_a_id = feedback.model_a_id
-        model_b_id = feedback.model_b_id
 
         # Update arm A: move in direction of preference
         self.preference_weights[model_a_id] += self.learning_rate * gradient_scale * x

--- a/conduit/engines/bandits/epsilon_greedy.py
+++ b/conduit/engines/bandits/epsilon_greedy.py
@@ -240,6 +240,13 @@ class EpsilonGreedyBandit(BanditAlgorithm):
         """
         model_id = feedback.model_id
 
+        # Validate model_id exists in available arms
+        if model_id not in self.arms:
+            raise ValueError(
+                f"Model ID '{model_id}' not in arms. "
+                f"Available: {list(self.arms.keys())}"
+            )
+
         # Calculate composite reward from quality, cost, and latency (Phase 3)
         reward = feedback.calculate_reward(
             quality_weight=self.reward_weights["quality"],

--- a/conduit/engines/bandits/linucb.py
+++ b/conduit/engines/bandits/linucb.py
@@ -224,6 +224,13 @@ class LinUCBBandit(BanditAlgorithm):
         """
         model_id = feedback.model_id
 
+        # Validate model_id exists in available arms
+        if model_id not in self.arms:
+            raise ValueError(
+                f"Model ID '{model_id}' not in arms. "
+                f"Available: {list(self.arms.keys())}"
+            )
+
         # Calculate composite reward from quality, cost, and latency (Phase 3)
         reward = feedback.calculate_reward(
             quality_weight=self.reward_weights["quality"],

--- a/conduit/engines/bandits/thompson_sampling.py
+++ b/conduit/engines/bandits/thompson_sampling.py
@@ -184,6 +184,13 @@ class ThompsonSamplingBandit(BanditAlgorithm):
         """
         model_id = feedback.model_id
 
+        # Validate model_id exists in available arms
+        if model_id not in self.arms:
+            raise ValueError(
+                f"Model ID '{model_id}' not in arms. "
+                f"Available: {list(self.arms.keys())}"
+            )
+
         # Calculate composite reward from quality, cost, and latency (Phase 3)
         reward = feedback.calculate_reward(
             quality_weight=self.reward_weights["quality"],
@@ -320,7 +327,7 @@ class ThompsonSamplingBandit(BanditAlgorithm):
         """
         if state.algorithm != "thompson_sampling":
             raise ValueError(
-                f"State algorithm '{state.algorithm}' != 'thompson_sampling'"
+                f"State algorithm '{state.algorithm}' mismatch: expected 'thompson_sampling'"
             )
 
         # Verify arms match

--- a/conduit/engines/bandits/ucb.py
+++ b/conduit/engines/bandits/ucb.py
@@ -206,6 +206,13 @@ class UCB1Bandit(BanditAlgorithm):
         """
         model_id = feedback.model_id
 
+        # Validate model_id exists in available arms
+        if model_id not in self.arms:
+            raise ValueError(
+                f"Model ID '{model_id}' not in arms. "
+                f"Available: {list(self.arms.keys())}"
+            )
+
         # Calculate composite reward from quality, cost, and latency (Phase 3)
         reward = feedback.calculate_reward(
             quality_weight=self.reward_weights["quality"],


### PR DESCRIPTION
Fixes contract validation test failures by adding model_id validation to update() methods:
- LinUCB, Thompson Sampling, UCB1, Epsilon-Greedy, Contextual Thompson Sampling: validate model_id in update()
- Dueling: validate both model_a_id and model_b_id in update()
- Thompson Sampling: fix from_state() error message to match regex "algorithm.*mismatch"

All 17 contract validation tests now pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)