### PR TITLE
Fix Router.update() to use real features instead of dummy values

### DIFF
--- a/tests/integration/test_auto_persistence.py
+++ b/tests/integration/test_auto_persistence.py
@@ -65,6 +65,7 @@ async def test_auto_load_on_first_route(state_store):
             cost=0.001,
             quality_score=0.8,
             latency=1.0,
+            features=decision.features,
         )
 
     initial_query_count = router1.hybrid_router.query_count
@@ -116,6 +117,7 @@ async def test_save_after_every_update(state_store):
         cost=0.001,
         quality_score=0.9,
         latency=1.0,
+        features=decision.features,
     )
 
     # State should be saved immediately after update
@@ -267,6 +269,7 @@ async def test_crash_recovery_simulation(state_store):
             cost=0.001,
             quality_score=0.75,
             latency=1.0,
+            features=decision.features,
         )
 
     assert router1.hybrid_router.query_count == 10


### PR DESCRIPTION
Router.update() was using dummy features (all zeros) for bandit updates, completely breaking contextual learning in LinUCB. This fix adds a features parameter to accept real query features from routing decisions.

Changes:
- Add features: QueryFeatures parameter to Router.update()
- Remove dummy feature generation that was breaking contextual learning
- Update test callers to pass decision.features
- Add QueryFeatures to router.py imports

Impact: Restores proper contextual bandit learning for LinUCB algorithm

🤖 Generated with [Claude Code](https://claude.com/claude-code)