### PR TITLE
Add gpt-5 to default_models list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -420,10 +420,12 @@ uv run python examples/02_routing/basic_routing.py
 models:
   # Default routing pool (balanced across providers)
   default:
-    - o4-mini               # OpenAI fast reasoning
+    - o4-mini               # OpenAI budget
+    - gpt-5                 # OpenAI mid-tier
     - gpt-5.1               # OpenAI flagship
-    - claude-sonnet-4-5-20241124  # Anthropic balanced
-    - gemini-2.5-flash      # Google fast
+    - claude-sonnet-4.5     # Anthropic balanced
+    - claude-opus-4.5       # Anthropic premium
+    - gemini-2.5-pro        # Google flagship
 
   # Arbiter evaluation (cheap, fast)
   arbiter: o4-mini

--- a/conduit/core/config.py
+++ b/conduit/core/config.py
@@ -82,6 +82,7 @@ class Settings(BaseSettings):
     default_models: list[str] = Field(
         default=[
             "o4-mini",  # OpenAI - cheap, fast reasoning
+            "gpt-5",  # OpenAI - mid-tier, strong reasoning
             "gpt-5.1",  # OpenAI - latest flagship
             "claude-sonnet-4.5",  # Anthropic - balanced quality
             "claude-opus-4.5",  # Anthropic - premium quality


### PR DESCRIPTION
## Summary

Fixes inconsistency where gpt-5 (aliased to gpt-4o) was referenced in conduit.yaml priors but missing from default_models in config.py.

## Changes

- Add "gpt-5" as second model in default_models (between o4-mini and gpt-5.1)
- Update AGENTS.md documentation example to match actual defaults
- Fills OpenAI mid-tier gap (previously had budget + flagship, but no mid-tier)

## Rationale

- gpt-5 already configured in LiteLLM mapping (config.py line 965) and pricing (line 1030)
- Already in conduit.yaml priors section (line 52)
- Better math/reasoning than gpt-4-turbo (per issue rationale)
- Aligns with conduit-benchmark EXPERIMENTAL_DESIGN.md (6 models)

## Result

default_models now has 6 models (1 budget, 1 mid-tier, 4 flagship) for balanced exploration:
- o4-mini (budget)
- gpt-5 (mid-tier) **NEW**
- gpt-5.1 (flagship)
- claude-sonnet-4.5 (balanced)
- claude-opus-4.5 (premium)
- gemini-2.5-pro (flagship)

## Testing

- Config imports correctly
- Pre-push hooks passed (ruff, black, mypy, tests)
- All fast unit tests passing

Closes #171

🤖 Generated with [Claude Code](https://claude.com/claude-code)