### PR TITLE
Improve Pydantic usage with computed_field and typed models (fixes #179)

### DIFF
--- a/conduit/api/validation.py
+++ b/conduit/api/validation.py
@@ -4,6 +4,24 @@ from typing import Any
 
 from pydantic import BaseModel, Field
 
+from conduit.core.models import QueryConstraints
+
+
+class ContextMetadata(BaseModel):
+    """Optional context metadata for routing requests.
+
+    Provides structured fields for common context information while
+    allowing arbitrary extra fields for application-specific data.
+    All fields are optional to maximize flexibility.
+    """
+
+    source: str | None = Field(None, description="Request source identifier")
+    session_id: str | None = Field(None, description="Session identifier")
+    request_id: str | None = Field(None, description="External request ID")
+    tags: list[str] | None = Field(None, description="Optional tags for categorization")
+
+    model_config = {"extra": "allow"}
+
 
 class CompleteRequest(BaseModel):
     """Request schema for POST /v1/complete."""
@@ -12,12 +30,12 @@ class CompleteRequest(BaseModel):
     result_type: str | None = Field(
         None, description="Pydantic model name for structured output (optional)"
     )
-    constraints: dict[str, Any] | None = Field(
+    constraints: QueryConstraints | None = Field(
         None,
         description="Optional routing constraints (max_cost, max_latency, min_quality, preferred_provider)",
     )
     user_id: str | None = Field(None, description="User identifier for tracking")
-    context: dict[str, Any] | None = Field(
+    context: ContextMetadata | None = Field(
         None, description="Additional context metadata"
     )
 

--- a/conduit/core/models.py
+++ b/conduit/core/models.py
@@ -9,7 +9,7 @@ from datetime import datetime, timezone
 from typing import Any, Literal
 from uuid import uuid4
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, computed_field, field_validator
 
 
 class UserPreferences(BaseModel):
@@ -261,11 +261,13 @@ class ModelState(BaseModel):
         description="Last update timestamp",
     )
 
+    @computed_field
     @property
     def mean_success_rate(self) -> float:
         """Expected success rate (mean of Beta distribution)."""
         return self.alpha / (self.alpha + self.beta)
 
+    @computed_field
     @property
     def variance(self) -> float:
         """Variance of Beta distribution."""

--- a/conduit/core/pricing.py
+++ b/conduit/core/pricing.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 
 class ModelPricing(BaseModel):
@@ -51,16 +51,19 @@ class ModelPricing(BaseModel):
         description="Timestamp when this pricing snapshot was recorded",
     )
 
+    @computed_field
     @property
     def input_cost_per_token(self) -> float:
         """Cost per single input token in dollars."""
         return self.input_cost_per_million / 1_000_000.0
 
+    @computed_field
     @property
     def output_cost_per_token(self) -> float:
         """Cost per single output token in dollars."""
         return self.output_cost_per_million / 1_000_000.0
 
+    @computed_field
     @property
     def cached_input_cost_per_token(self) -> float | None:
         """Cost per single cached input token in dollars, if available."""

--- a/conduit/engines/bandits/base.py
+++ b/conduit/engines/bandits/base.py
@@ -8,7 +8,7 @@ from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 
 from conduit.core.config import load_feature_dimensions
 from conduit.core.models import QueryFeatures
@@ -39,6 +39,7 @@ class ModelArm(BaseModel):
     expected_quality: float = 0.5
     metadata: dict[str, Any] = Field(default_factory=dict)
 
+    @computed_field
     @property
     def full_name(self) -> str:
         """Get full model name for PydanticAI."""

--- a/tests/unit/test_routes.py
+++ b/tests/unit/test_routes.py
@@ -103,9 +103,10 @@ class TestCompleteEndpoint:
         )
 
         assert response.status_code == 200
-        # Verify constraints were passed to service
+        # Verify constraints were passed to service (now as QueryConstraints model)
         call_args = mock_service.complete.call_args
-        assert call_args.kwargs["constraints"]["max_cost"] == 0.001
+        constraints = call_args.kwargs["constraints"]
+        assert constraints.max_cost == 0.001
 
     def test_complete_missing_prompt(self, client):
         """Test completion with missing prompt."""


### PR DESCRIPTION
## Summary
- Add `@computed_field` decorator to Pydantic model properties so they serialize correctly with `model_dump()`
- Create typed `ContextMetadata` model to replace `dict[str, Any]` in API layer
- Update `CompleteRequest` to use `QueryConstraints` and `ContextMetadata` typed models
- Update service layer to accept both typed models and dicts for backward compatibility

## Changes
- `conduit/core/models.py`: Added `@computed_field` to `ModelState.mean_success_rate` and `ModelState.variance`
- `conduit/engines/bandits/base.py`: Added `@computed_field` to `ModelArm.full_name`
- `conduit/core/pricing.py`: Added `@computed_field` to all cost-per-token properties
- `conduit/api/validation.py`: Created `ContextMetadata` typed model, use `QueryConstraints` for constraints
- `conduit/api/service.py`: Accept both typed models and dicts for backward compatibility
- `tests/unit/test_routes.py`: Updated test for typed constraints access

## Test plan
- [x] All 18 route tests pass
- [x] All bandit/model tests pass (188 tests)
- [x] Pre-push hooks pass (ruff, black, tests)
- [x] Verified `@computed_field` properties serialize correctly with `model_dump()`

Fixes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)