### PR TITLE
Fix hybrid_routing.py example for new HybridRouter API

### DIFF
--- a/examples/02_routing/hybrid_routing.py
+++ b/examples/02_routing/hybrid_routing.py
@@ -39,6 +39,7 @@ async def main():
         models=models,
         switch_threshold=15,  # Low threshold for demo (production: 2000)
         # feature_dim auto-detected from analyzer (recommended)
+        phase1_algorithm="ucb1",  # Use UCB1 for phase 1 (matches example docs)
         ucb1_c=2.0,  # Higher exploration parameter for demo
         linucb_alpha=2.0,  # Higher exploration parameter for demo
     )
@@ -154,8 +155,8 @@ async def main():
     print("=" * 80)
 
     # Get stats from both phases
-    ucb1_stats = router.ucb1.get_stats()
-    linucb_stats = router.linucb.get_stats()
+    ucb1_stats = router.phase1_bandit.get_stats()
+    linucb_stats = router.phase2_bandit.get_stats()
 
     print(f"Current phase: {router.current_phase}")
     print(f"Total queries: {router.query_count}")


### PR DESCRIPTION
## Summary
Fixes the hybrid_routing.py example to work with the new HybridRouter API after PR #169 changed the default algorithm from UCB1→LinUCB to Thompson Sampling→LinUCB.

## Changes
- Add `phase1_algorithm="ucb1"` to explicitly use UCB1 for phase 1 (matches example documentation)
- Change `router.ucb1` → `router.phase1_bandit` (new attribute name)
- Change `router.linucb` → `router.phase2_bandit` (new attribute name)

## Issue Fixed
**Error**: `KeyError: 'arm_mean_reward'` when example tried to access `ucb1_stats["arm_mean_reward"]`

**Root Cause**: 
- The example used old attribute names (`router.ucb1`, `router.linucb`) that no longer exist
- The HybridRouter now uses generic names (`router.phase1_bandit`, `router.phase2_bandit`) to support multiple algorithm combinations
- The default phase1 algorithm changed to Thompson Sampling, but the example docs expect UCB1

## Test Results
✅ Example runs successfully with correct statistics output:
- UCB1 Phase statistics showing mean rewards for each model
- LinUCB Phase statistics showing success rates for each model  
- Combined statistics showing total pulls across both phases

## Verification
```bash
PYTHONPATH=/Users/evan/Documents/gh/conduit uv run python examples/02_routing/hybrid_routing.py
# Output shows successful execution with full statistics
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)