### PR TITLE
Add justification for type: ignore in contextual Thompson sampling

### DIFF
--- a/conduit/engines/bandits/contextual_thompson_sampling.py
+++ b/conduit/engines/bandits/contextual_thompson_sampling.py
@@ -191,7 +191,7 @@ class ContextualThompsonSamplingBandit(BanditAlgorithm):
             sampled_rewards[model_id] = expected_reward
 
         # Select arm with highest sampled reward
-        selected_id = max(sampled_rewards, key=sampled_rewards.get)  # type: ignore
+        selected_id = max(sampled_rewards, key=sampled_rewards.get)  # type: ignore[arg-type]  # sampled_rewards.get returns Optional, safe here
         selected_arm = self.arms[selected_id]
 
         # Track queries


### PR DESCRIPTION
Fixes #242

This PR adds a specific mypy error code and a brief justification for an
existing `type: ignore` used during bandit arm selection.

The ignore is required because `dict.get` returns an Optional value, but
the usage here is safe by construction.
