### PR TITLE
Increase test_hybrid_routing timeout to 180s for CI stability

### DIFF
--- a/tests/regression/test_examples.py
+++ b/tests/regression/test_examples.py
@@ -164,10 +164,11 @@ def test_litellm_integration():
 def test_hybrid_routing():
     """Test examples/hybrid_routing.py runs successfully.
 
-    This example uses mock embeddings and does not require API keys.
+    This example uses local embeddings (FastEmbed or sentence-transformers)
+    and does not require API keys. First run may download model files (~100MB).
     """
     example = EXAMPLES_DIR / "hybrid_routing.py"
-    exit_code, stdout, stderr = run_example(example, timeout=60)
+    exit_code, stdout, stderr = run_example(example, timeout=180)
 
     assert exit_code == 0, f"Example failed with stderr: {stderr}"
 


### PR DESCRIPTION
## Summary
- Increases `test_hybrid_routing` timeout from 60s to 180s
- Corrects misleading docstring about mock embeddings

## Problem
The `hybrid_routing.py` example uses local embeddings (FastEmbed or sentence-transformers) which may need to download model files (~100MB) on first CI run. The 60-second timeout was insufficient, causing intermittent CI failures like the one in PR #261.

The PostgreSQL "role root does not exist" errors in CI logs are a red herring - those are just the health check running as root user (normal behavior). The actual failure was this timeout.

## Test plan
- [x] Verified test passes locally (17.52s)
- [x] 180s timeout matches other tests that may download models (e.g., `test_llamaindex_integration`)